### PR TITLE
Make more portable (for macOS and older versions of Bash).

### DIFF
--- a/ccolumn.bash
+++ b/ccolumn.bash
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env -S -i TERM=${TERM} bash
 
 screen_width=`tput cols` #current width of terminal	
 original_IFS=IFS #Record original IFS value

--- a/ccolumn.bash
+++ b/ccolumn.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 screen_width=`tput cols` #current width of terminal	
 original_IFS=IFS #Record original IFS value
@@ -76,7 +76,7 @@ setOptions()
 setColorArrays()
 {
 	#Assign input to arrays
-	while read -t 0.1 file; do #Read Times out after 0.1 seconds if no input
+	while read -t 1 file; do #Read Times out after 1 second if no input
 		colored=("${colored[@]}" "$file")
 		
 		local color_removed=$(removeColor "$file")
@@ -87,7 +87,7 @@ setColorArrays()
 
 removeColor()
 {
-	echo "$1" | sed -r 's/\[[^mK]*(m|K)//g' #Removes All linux Color Codes from String
+	echo "$1" | sed -E 's/\[[^mK]*(m|K)//g' #Removes All linux Color Codes from String
 }
 
 setRowSizesToZero()

--- a/ccolumn.bash
+++ b/ccolumn.bash
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S -i TERM=${TERM} bash
+#!/usr/bin/env bash
 
 screen_width=`tput cols` #current width of terminal	
 original_IFS=IFS #Record original IFS value


### PR DESCRIPTION
Hey there,

I found your script after some Googling on the topic, but had to mod it to work well with macOS (due to using the BSD version of sed, and made it more compatible with the older versions of Bash that ship with macOS). 

It's a really nice utility that worked well for my use case (filtering the output of `ls` but still using a multi-column output). 

The change to the `read` command could be made more sophisticated (e.g., use different flags for different versions of Bash, or fall back to `-t 1` if an error occurs. This is also unnecessary if running a later version of Bash that the `env` command can find, but thought it may be of interest if you care much about portability.

Cheers,
-Zac